### PR TITLE
Fix clojure cli

### DIFF
--- a/clojure/install
+++ b/clojure/install
@@ -2,7 +2,6 @@
 
 set -e
 
-cd /tmp
 curl -L -O https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh
 chmod +x linux-install.sh
 ./linux-install.sh

--- a/install.md
+++ b/install.md
@@ -21,7 +21,7 @@ Installs the latest version of
 Clojure (https://clojure.org/guides/install_clojure#_linux_instructions)
 
 ```bash
-curl -sS 'https://raw.githubusercontent.com/simplemono/a-la-carte/2555ec6605a704704737d2d22be77d84c1f5f4ad/clojure/install' | bash
+curl -sS 'https://raw.githubusercontent.com/simplemono/a-la-carte/aa29e3ea57a92817446be9a5a81faaca578f217c/clojure/install' | bash
 ```
 
 ## dev-user


### PR DESCRIPTION
Fix: clojure/install will not work if you use it with `| sudo bash`
since root seems not to be allowed to write into the `/tmp` folder of
the current user ('curl: (23) Failure writing output to destination').